### PR TITLE
Added override option for "continuous" setting

### DIFF
--- a/annyang.js
+++ b/annyang.js
@@ -38,7 +38,6 @@
   var recognition;
   var callbacks = { start: [], error: [], end: [], result: [], resultMatch: [], resultNoMatch: [], errorNetwork: [], errorPermissionBlocked: [], errorPermissionDenied: [] };
   var autoRestart;
-  var forceContinuous;
   var lastStartedAt = 0;
   var debugState = false;
   var debugStyle = 'font-weight: bold; color: #00f;';
@@ -122,7 +121,7 @@
 
       // In HTTPS, turn off continuous mode for faster results.
       // In HTTP,  turn on  continuous mode for much slower results, but no repeating security notices
-      recognition.continuous = forceContinuous || root.location.protocol === 'http:';
+      recognition.continuous = root.location.protocol === 'http:';
 
       // Sets the language to the default 'en-US'. This can be changed with annyang.setLanguage()
       recognition.lang = 'en-US';
@@ -228,9 +227,10 @@
       } else {
         autoRestart = true;
       }
-      if (options.forceContinuous !== undefined) {
-        forceContinuous = !!options.forceContinuous;
+      if (options.continuous !== undefined) {
+        recognition.continuous = !!options.continuous;
       }
+
       lastStartedAt = new Date().getTime();
       recognition.start();
     },


### PR DESCRIPTION
As per this issue, would like to add a flag for https clients to force the continue flag to be set on the recognizer.

https://github.com/TalAter/annyang/issues/70

Thanks,

Kean
