### PR TITLE
Support Chrome on Android

### DIFF
--- a/annyang.js
+++ b/annyang.js
@@ -192,7 +192,9 @@
         // Map the results to an array
         var SpeechRecognitionResult = event.results[event.resultIndex];
         var results = [];
-        for (var k = 0; k<SpeechRecognitionResult.length; k++) {
+        // Enforce maxAlternatives (not respected by Chrome on Android)
+        var K = Math.min(SpeechRecognitionResult.length, recognition.maxAlternatives);
+        for (var k = 0; k < K; k++) {
           results[k] = SpeechRecognitionResult[k].transcript;
         }
 


### PR DESCRIPTION
This PR implements workarounds for two bugs in SpeechRecognition in Chrome on Android:
- `SpeechRecognition.maxAlternatives` is not respected; 5 alternatives are returned regardless of the attribute value.
- Just before `SpeechRecognition.onend()` is called, an extra `SpeechRecognitionResultEvent` is triggered whose `results` attribute contains a `SpeechRecognitionResultList` in which the `transcript` of each `item` is the concatenation of `transcript`s of seemingly random positions in the `SpeechRecognitionResultList`s seen since the last time `.start()` was called. For example:

```
Say "blue"
Returned:
1 "blue"
2 "Blu"
3 "Blue"
4 "blew"
5 "Bleu"

Say "yellow"
Returned:
A "yellow"
B "Yello"
C "hello"
D "yelo"
E "Yellow"

Wait for onend() to be triggered
Returned:
1A "blue yellow"
2A "Blu yellow"
3A "Blue yellow"
4A "blew yellow"
1B "blue Yello"
```
