### PR TITLE
Remove unnecessary command spying from result callback tests

### DIFF
--- a/test/spec/BasicSpec.js
+++ b/test/spec/BasicSpec.js
@@ -289,7 +289,6 @@
 
     var recognition;
     var spyOnResultMatch;
-    var spyOnCommand;
     var args;
     var saveArguments = function() {
       args = arguments;
@@ -299,12 +298,11 @@
       annyang.debug(false);
       recognition = annyang.getSpeechRecognizer();
       spyOnResultMatch = jasmine.createSpy();
-      spyOnCommand = jasmine.createSpy();
       annyang.abort();
       annyang.start();
       annyang.removeCommands();
       annyang.addCommands({
-        'Time for some thrilling :action': spyOnCommand
+        'Time for some thrilling :action': function() {}
       });
     });
 
@@ -313,7 +311,6 @@
       expect(spyOnResultMatch).not.toHaveBeenCalled();
       recognition.say('Time for some thrilling heroics');
       expect(spyOnResultMatch).toHaveBeenCalledTimes(1);
-      expect(spyOnCommand).toHaveBeenCalledTimes(1);
     });
 
     it('should add a callback which will not be called when result returned from Speech Recognition does not match a command', function() {
@@ -356,18 +353,16 @@
 
     var recognition;
     var spyOnResultNoMatch;
-    var spyOnCommand;
 
     beforeEach(function() {
       annyang.debug(false);
       recognition = annyang.getSpeechRecognizer();
       spyOnResultNoMatch = jasmine.createSpy();
-      spyOnCommand = jasmine.createSpy();
       annyang.abort();
       annyang.start();
       annyang.removeCommands();
       annyang.addCommands({
-        'Time for some thrilling heroics': spyOnCommand
+        'Time for some thrilling heroics': function() {}
       });
     });
 
@@ -376,7 +371,6 @@
       expect(spyOnResultNoMatch).not.toHaveBeenCalled();
       recognition.say('That sounds like something out of science fiction');
       expect(spyOnResultNoMatch).toHaveBeenCalledTimes(1);
-      expect(spyOnCommand).not.toHaveBeenCalled();
     });
 
     it('should add a callback which will not be called when result returned from Speech Recognition matches a command', function () {


### PR DESCRIPTION
Removes some unnecessary spying on commands from result matching callbacks as mentioned in #160 