### PR TITLE
Added tests in annyang.pause to check if running after abort.

### DIFF
--- a/test/spec/BasicSpec.js
+++ b/test/spec/BasicSpec.js
@@ -141,7 +141,6 @@
       expect(annyang.isListening()).toBe(false);
       expect(spyOnEnd).not.toHaveBeenCalled();
     });
-
   });
 
   describe('annyang.start', function() {
@@ -189,7 +188,6 @@
       annyang.debug(false);
       expect(console.log).toHaveBeenCalledWith('Failed to execute \'start\' on \'SpeechRecognition\': recognition has already started.');
     });
-
   });
 
   describe('annyang.debug', function() {
@@ -1048,6 +1046,23 @@
       expect(recognition.isStarted()).toBe(true);
       annyang.pause();
       expect(recognition.isStarted()).toBe(true);
+    });
+
+
+    it('should leave annyang paused if called after annyang.abort()', function(){
+      expect(annyang.isListening()).toBe(true);
+      annyang.abort();
+      expect(annyang.isListening()).toBe(false);
+      annyang.pause();
+      expect(annyang.isListening()).toBe(false);
+    });
+
+    it('should leave the browser \'Speech Recognition off, if called after annyang.abort()', function(){
+      expect(recognition.isStarted()).toBe(true);
+      annyang.abort();
+      expect(recognition.isStarted()).toBe(false);
+      annyang.pause();
+      expect(recognition.isStarted()).toBe(false);
     });
 
   });


### PR DESCRIPTION
This is a pull request for first-timers-only: Add test to make sure pausing while speech recognition is off works properly #165 .  I added two tests to the annyang.pause section.  One checks if the annyang stays paused if called after abort().  The other checks if browser speech recognition remains off if paused after an abort.