### PR TITLE
Support for Universal Module Definition (UMD)

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -23,5 +23,8 @@
   "sub"       : true,
   "strict"    : true,
   "white"     : false,
-  "indent"    : 2
+  "indent"    : 2,
+  "globals"   : {
+    "define" : false
+  }
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -99,6 +99,20 @@ module.exports = function(grunt) {
             }
           }
         }
+      },
+      browserAMD: {
+        src: ['annyang.js'],
+        options: {
+          specs: 'test/spec/*Spec.js',
+          outfile: 'test/SpecRunner.html',
+          vendor: ['test/vendor/corti.js', 'test/init_corti.js'], // https://github.com/cloudchen/grunt-template-jasmine-requirejs/issues/72
+          template: require('grunt-template-jasmine-requirejs'),
+          templateOptions: {
+            requireConfig: {
+              baseUrl: '../'
+            }
+          }
+        }
       }
     }
   });

--- a/annyang.js
+++ b/annyang.js
@@ -3,8 +3,19 @@
 //! author  : Tal Ater @TalAter
 //! license : MIT
 //! https://www.TalAter.com/annyang/
-
-(function(undefined) {
+(function (root, factory) {
+  // istanbul ignore next
+  // jshint strict: false
+  if (typeof define === 'function' && define.amd) { // AMD
+    define([], function () {
+      return (root.annyang = factory(root, undefined));
+    });
+  } else if (typeof module === 'object' && module.exports) { // CommonJS
+    module.exports = factory(root, undefined);
+  } else { // Browser globals
+    root.annyang = factory(root, undefined);
+  }
+}(typeof window !== 'undefined' ? window : this, function (root, undefined) {
   "use strict";
 
   /**
@@ -17,8 +28,7 @@
    * # API Reference
    */
 
-  // Save a reference to the global object (window in the browser)
-  var root = this;
+  var annyang = {};
 
   // Get the SpeechRecognition object, while handling browser prefixes
   var SpeechRecognition = root.SpeechRecognition ||
@@ -30,7 +40,6 @@
   // Check browser support
   // This is done as early as possible, to make it as fast as possible for unsupported browsers
   if (!SpeechRecognition) {
-    root.annyang = null;
     return undefined;
   }
 
@@ -75,18 +84,18 @@
 
   var initIfNeeded = function() {
     if (!isInitialized()) {
-      root.annyang.init({}, false);
+      annyang.init({}, false);
     }
   };
 
   var registerCommand = function(command, cb, phrase) {
     commandsList.push({ command: command, callback: cb, originalPhrase: phrase });
     if (debugState) {
-      root.console.log('Command successfully loaded: %c'+phrase, debugStyle);
+      console.log('Command successfully loaded: %c'+phrase, debugStyle);
     }
   };
 
-  root.annyang = {
+  annyang = {
 
     /**
      * Initialize annyang with a list of commands to recognize.
@@ -169,9 +178,9 @@
           // play nicely with the browser, and never restart annyang automatically more than once per second
           var timeSinceLastStart = new Date().getTime()-lastStartedAt;
           if (timeSinceLastStart < 1000) {
-            setTimeout(root.annyang.start, 1000-timeSinceLastStart);
+            setTimeout(annyang.start, 1000-timeSinceLastStart);
           } else {
-            root.annyang.start();
+            annyang.start();
           }
         }
       };
@@ -179,7 +188,7 @@
       recognition.onresult  = function(event) {
         if(pauseListening) {
           if (debugState) {
-            root.console.log('Speech heard, but annyang is paused');
+            console.log('Speech heard, but annyang is paused');
           }
           return false;
         }
@@ -198,7 +207,7 @@
           // the text recognized
           commandText = results[i].trim();
           if (debugState) {
-            root.console.log('Speech recognized: %c'+commandText, debugStyle);
+            console.log('Speech recognized: %c'+commandText, debugStyle);
           }
 
           // try and match recognized text to one of the commands on the list
@@ -208,9 +217,9 @@
             if (result) {
               var parameters = result.slice(1);
               if (debugState) {
-                root.console.log('command matched: %c'+currentCommand.originalPhrase, debugStyle);
+                console.log('command matched: %c'+currentCommand.originalPhrase, debugStyle);
                 if (parameters.length) {
-                  root.console.log('with parameters', parameters);
+                  console.log('with parameters', parameters);
                 }
               }
               // execute the matched command
@@ -270,7 +279,7 @@
         recognition.start();
       } catch(e) {
         if (debugState) {
-          root.console.log(e.message);
+          console.log(e.message);
         }
       }
     },
@@ -309,7 +318,7 @@
      * @method resume
      */
     resume: function() {
-      root.annyang.start();
+      annyang.start();
     },
 
     /**
@@ -371,7 +380,7 @@
             registerCommand(new RegExp(cb.regexp.source, 'i'), cb.callback, phrase);
           } else {
             if (debugState) {
-              root.console.log('Can not register command: %c'+phrase, debugStyle);
+              console.log('Can not register command: %c'+phrase, debugStyle);
             }
             continue;
           }
@@ -544,7 +553,9 @@
     }
   };
 
-}).call(this);
+  return annyang;
+
+}));
 
 /**
  * # Good to Know

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-contrib-jasmine": "^1.0.0",
     "grunt-template-jasmine-istanbul": "^0.4.0",
+    "grunt-template-jasmine-requirejs": "^0.2.3",
     "grunt-markdox": "^1.2.1"
   }
 }

--- a/test/spec/.jshintrc
+++ b/test/spec/.jshintrc
@@ -34,6 +34,7 @@
     "spyOn":              false,
     "it":                 false,
     "xit":                false,
-    "annyang":            false
+    "annyang":            false,
+    "define":             false
   }
 }

--- a/test/spec/BasicSpec.js
+++ b/test/spec/BasicSpec.js
@@ -1,4 +1,13 @@
-(function() {
+(function (root, factory) {
+  // jshint strict: false
+  if (typeof module === 'object' && module.exports) { // CommonJS
+    factory(require('../../annyang'));
+  } else if (typeof define === 'function' && define.amd) { // AMD
+    define(['annyang'], factory);
+  } else { // Browser globals
+    factory(root.annyang);
+  }
+}(typeof window !== 'undefined' ? window : this, function factory(annyang) {
   "use strict";
 
   describe('annyang', function() {
@@ -1172,4 +1181,4 @@
 
   });
 
-})();
+}));

--- a/test/vendor/corti.js
+++ b/test/vendor/corti.js
@@ -4,11 +4,19 @@
 //! license : MIT
 //! https://github.com/TalAter/SpeechKITT/test/corti.js
 
-(function (undefined) {
+(function (root, factory) {
+  // jshint strict: false
+  if (typeof define === 'function' && define.amd) { // AMD. Register as an anonymous module.
+    define([], function () {
+      return (root.Corti = factory(root, undefined));
+    });
+  } else if (typeof module === 'object' && module.exports) { // CommonJS
+    module.exports = factory(root, undefined);
+  } else { // Browser globals
+    root.Corti = factory(root, undefined);
+  }
+}(typeof window !== 'undefined' ? window : this, function (_root, undefined) {
   "use strict";
-
-  // Save a reference to the global object (window in the browser)
-  var _root = this;
 
   // Holds the browser's implementation
   var _productionVersion = false;
@@ -164,7 +172,7 @@
   };
 
   // Expose functionality
-  _root.Corti = {
+  return {
     patch: function() {
       if (_productionVersion === false) {
         _productionVersion = _root.SpeechRecognition ||
@@ -181,4 +189,4 @@
     }
   };
 
-}).call(this);
+}));


### PR DESCRIPTION
This pull request adds [Universal Module Definition](https://github.com/umdjs/umd) support, allowing **annyang** to be used as a module.

## Motivation and Context
First of all, support for UMD is vital nowadays because many developers prefer to use modules. It's 2016 :tada: and we use [Webpack](https://github.com/webpack/webpack)/[Browserify](https://github.com/substack/node-browserify)/[RequireJS](https://github.com/requirejs/requirejs)/etc :tophat: in order to speed up development using modules. However, there are two major patterns that are used by developers when defining their modules - AMD and CommonJS. It'd be disrespectful to support single approach withdrawing a lot of potential users by not supporting another one.

Secondly, it resolves #174.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Because there are no changes in API, test suite was not changed.

Furthermore, support for UMD is done in backward compatible manner, so there is no need for major version bump. `annyang` is still available as a property of global `window` object. 

The only change to tests is the use of UMD when initialising the suite (updated for Corti as well). However, in order to test the module when it's used as a module, test suite is ran once again but with the use of `grunt-template-jasmine-requirejs`
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
JSHint configuration had to be updated in order to allow `define` to be a global variable.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.