### PR TITLE
Speed up Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - "5"


### PR DESCRIPTION
## Description
Use Travis CI container-based infrastructure instead of legacy one.

## Motivation and Context
See reasons why it should be done [here](https://docs.travis-ci.com/user/migrating-from-legacy/#Why-migrate-to-container-based-infrastructure%3F)