### PR TITLE
Resolves #210 add behavior to accept command object that does not have a regexp property

### DIFF
--- a/annyang.js
+++ b/annyang.js
@@ -395,9 +395,14 @@
           if (typeof cb === 'function') {
             // convert command to regex then register the command
             registerCommand(commandToRegExp(phrase), cb, phrase);
-          } else if (typeof cb === 'object' && cb.regexp instanceof RegExp) {
-            // register the command
-            registerCommand(new RegExp(cb.regexp.source, 'i'), cb.callback, phrase);
+          } else if (typeof cb === 'object') {
+            if (cb.regexp instanceof RegExp) {
+              // register the command
+              registerCommand(new RegExp(cb.regexp.source, 'i'), cb.callback, phrase); 
+            } else {
+              // convert command to regex then register the command
+              registerCommand(commandToRegExp(phrase), cb, phrase);
+            }
           } else {
             if (debugState) {
               logMessage('Can not register command: %c'+phrase, debugStyle);

--- a/test/spec/BasicSpec.js
+++ b/test/spec/BasicSpec.js
@@ -895,6 +895,31 @@
       recognition.say('Time for some thrilling heroics');
       expect(spyOnMatch).toHaveBeenCalledTimes(1);
     });
+    
+    it('should accept commands with an object as the value which consists of just a callback', function() {
+      expect(function() {
+        annyang.addCommands(
+        {
+          'It is time': {
+            callback: function() {}
+          }
+        });
+      }).not.toThrowError();
+    });
+
+    it('should match commands passed as an object as the value which consists of just a callback', function() {
+      var spyOnMatch = jasmine.createSpy();
+      annyang.addCommands(
+        {
+          'It is time': {
+            callback: spyOnMatch
+          }
+        }
+      );
+      expect(spyOnMatch).not.toHaveBeenCalled();
+      recognition.say('It is time');
+      expect(spyOnMatch).toHaveBeenCalledTimes(1);
+    });
 
     it('should pass variables from regexp capturing groups to the callback function', function() {
       var capture1 = '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
change `annyang.addCommands`
adds two tests



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
see #210 . this would allow an extra form of command object to be valid.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The new tests currently do NOT pass. I don't understand why.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

…perty