### PR TITLE
Adding details for using annyang in Chromium, Electron, and Cordova

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,6 +6,8 @@
 - [Why does Speech Recognition repeatedly starts and stops?](#why-does-speech-recognition-repeatedly-starts-and-stops)
 - [Can annyang work offline?](#can-annyang-work-offline)
 - [Can annyang be used to capture the full text spoken by the user?](#can-annyang-be-used-to-capture-the-full-text-spoken-by-the-user)
+- [Can annyang be used in Chromium or Electron?](#can-annyang-be-used-in-chromium-or-electron)
+- [Can annyang be used in Cordova?](#can-annyang-be-used-in-cordova)
 
 ## What languages are supported?
 
@@ -143,3 +145,20 @@ annyang.addCallback('resultNoMatch', function(phrases) {
   console.log("But then again, it could be any of the following: ", phrases);
 });
 ````
+
+## Can annyang be used in Chromium or Electron?
+
+Yes, however you must create your own Chromium keys and are limeted to 50 requests/day. To do this you'll need to provide your own keys at runtime by following the instructions for [Acquiring Keys](https://www.chromium.org/developers/how-tos/api-keys) in the Chromium developer docs. 
+
+## Can annyang be used in Cordova?
+
+Yes. In order to use `webKitSpeechRecognition` you must use [Crosswalk](https://github.com/crosswalk-project/cordova-plugin-crosswalk-webview) and the [Cordova Media Plugin](https://github.com/apache/cordova-plugin-media). These can be added to an existing cordova project with the following commands:
+
+```
+cordova plugin add cordova-plugin-crosswalk-webview
+cordova plugin add cordova-plugin-media
+```
+**Known issues:**
+ - This has only been verified to work Android.
+ - This will not work on a device without a SpeechRecognizer ([like the Kindel Fire](https://forums.developer.amazon.com/questions/13597/does-speech-recognition-work-in-kindle-fire-hd-tab.html)) unless you sideload the [Google Now Launcher](https://play.google.com/store/apps/details?id=com.google.android.launcher).
+ - Your app will ding with the native speech recognition sound, you have no control over this. See [#194](https://github.com/TalAter/annyang/issues/194).


### PR DESCRIPTION
## Description
Adding documentation to the FAQ containing details about how to run annyang on the following platforms:
- [Chromium](https://www.chromium.org/)
- [Electron](http://electron.atom.io/)
- [Cordova](https://cordova.apache.org/)

## Motivation and Context
There have been a number of questions about running annyang outside of the typical Chrome environment, hopefully these FAQ updates will help folks figure it out. For more info see #188.

@TalAter hopefully this is what you were looking for :smile: 

## How Has This Been Tested?
These steps have been followed to enable my [smart-mirror](https://github.com/evancohen/smart-mirror) on the aforementioned platforms.
[Relevant smart-mirror docs](http://docs.smart-mirror.io/docs/chromium_speech_keys.html).

## Types of changes
Documentation only.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

