### PR TITLE
Returns the result during recognition

### DIFF
--- a/dist/annyang.js
+++ b/dist/annyang.js
@@ -48,7 +48,7 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 
   var commandsList = [];
   var recognition;
-  var callbacks = { start: [], error: [], end: [], soundstart: [], result: [], resultMatch: [], resultNoMatch: [], errorNetwork: [], errorPermissionBlocked: [], errorPermissionDenied: [] };
+  var callbacks = { start: [], error: [], end: [], soundstart: [], live: [], result: [], resultMatch: [], resultNoMatch: [], errorNetwork: [], errorPermissionBlocked: [], errorPermissionDenied: [] };
   var autoRestart;
   var lastStartedAt = 0;
   var autoRestartCount = 0;
@@ -177,6 +177,9 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
       // Set the max number of alternative transcripts to try and match with a command
       recognition.maxAlternatives = 5;
 
+      // Returns the result during recognition
+      recognition.interimResults = true;
+
       // In HTTPS, turn off continuous mode for faster results.
       // In HTTP,  turn on  continuous mode for much slower results, but no repeating security notices
       recognition.continuous = root.location.protocol === 'http:';
@@ -251,7 +254,9 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
           results[k] = SpeechRecognitionResult[k].transcript;
         }
 
-        parseResults(results);
+        invokeCallbacks(callbacks.live, results[0]);
+        if (event.results[ 0 ].isFinal)
+          parseResults(results);
       };
 
       // build commands list


### PR DESCRIPTION
## Description
The 'interimResults' parameter of SpeechRecognition allows to return a result to each word, I activated it and added a small condition to detect the end of the sentence.

## Motivation and Context
I wish to display during the speech recognition, what I was pronouncing, but I did not find this functionality.

## How Has This Been Tested?
Simply by using the invocation of the event added to 'callbacks', I found there the variable 'isFinal' which differentiates the current recognition of the end of sentence.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
