### PR TITLE
README: Improve readability, fix a typo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -146,26 +146,44 @@ annyang.removeCommands(['howdy', 'hi']);
 
 Add a callback function to be called in case one of the following events happens:
 
-* `start` - Fired as soon as the browser's Speech Recognition engine starts listening
+* `start` - Fired as soon as the browser's Speech Recognition engine starts listening.
+
 * `soundstart` - Fired as soon as any sound (possibly speech) has been detected.
-    This will fire once per Speech Recognition starting. See https://is.gd/annyang_sound_start
-* `error` - Fired when the browser's Speech Recogntion engine returns an error, this generic error callback will be followed by more accurate error callbacks (both will fire if both are defined)
-    Callback function will be called with the error event as the first argument
-* `errorNetwork` - Fired when Speech Recognition fails because of a network error
-    Callback function will be called with the error event as the first argument
+
+    This will fire once per Speech Recognition starting. See https://is.gd/annyang_sound_start.
+
+* `error` - Fired when the browser's Speech Recogntion engine returns an error, this generic error callback will be followed by more accurate error callbacks (both will fire if both are defined).
+
+    Callback function will be called with the error event as the first argument.
+
+* `errorNetwork` - Fired when Speech Recognition fails because of a network error.
+
+    Callback function will be called with the error event as the first argument.
+
 * `errorPermissionBlocked` - Fired when the browser blocks the permission request to use Speech Recognition.
-    Callback function will be called with the error event as the first argument
+
+    Callback function will be called with the error event as the first argument.
+
 * `errorPermissionDenied` - Fired when the user blocks the permission request to use Speech Recognition.
-    Callback function will be called with the error event as the first argument
-* `end` - Fired when the browser's Speech Recognition engine stops
+
+    Callback function will be called with the error event as the first argument.
+
+* `end` - Fired when the browser's Speech Recognition engine stops.
+
 * `result` - Fired as soon as some speech was identified. This generic callback will be followed by either the `resultMatch` or `resultNoMatch` callbacks.
-    Callback functions for to this event will be called with an array of possible phrases the user said as the first argument
-* `resultMatch` - Fired when annyang was able to match between what the user said and a registered command
+
+    Callback functions for this event will be called with an array of possible phrases the user said as the first argument.
+
+* `resultMatch` - Fired when annyang was able to match between what the user said and a registered command.
+
     Callback functions for this event will be called with three arguments in the following order:
-      * The phrase the user said that matched a command
-      * The command that was matched
-      * An array of possible alternative phrases the user might have said
+
+    * The phrase the user said that matched a command.
+    * The command that was matched.
+    * An array of possible alternative phrases the user might have said.
+
 * `resultNoMatch` - Fired when what the user said didn't match any of the registered commands.
+
     Callback functions for this event will be called with an array of possible phrases the user might've said as the first argument
 
 #### Examples:


### PR DESCRIPTION
* The preview wasn't matching the markdown, making it harder to apprehend (missing periods, missing list formatting).
* Typo: “Callback functions for to this event” -> “Callback functions for this event”.
