### PR TITLE
Changed paused default to false in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ Receives an optional options object which supports the following options:
 
 - `autoRestart`  (boolean, default: true) Should annyang restart itself if it is closed indirectly, because of silence or window conflicts?
 - `continuous`   (boolean) Allow forcing continuous mode on or off. Annyang is pretty smart about this, so only set this if you know what you're doing.
-- `paused`       (boolean, default: true) Start annyang in paused mode.
+- `paused`       (boolean, default: false) Start annyang in paused mode.
 
 #### Examples:
 ````javascript


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The paused parameter was mistakenly true by default in the documentation.

## Motivation and Context
Improve documentation.

## How Has This Been Tested?
Just a documentation update.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
