### PR TITLE
ensure that parameters are always set if empty

### DIFF
--- a/src/annyang.js
+++ b/src/annyang.js
@@ -135,6 +135,9 @@
         var result = currentCommand.command.exec(commandText);
         if (result) {
           var parameters = result.slice(1);
+          if (parameters.length == 0) {
+            parameters = result;
+          }
           if (debugState) {
             logMessage(
               'command matched: %c' + currentCommand.originalPhrase,


### PR DESCRIPTION
When using `addCommands` using the RegEx syntax to hit a callback I was noticing that it didn't return the matched phrase. That's because the data `parseResults` was running `slice(1)` and not returning anything. There should be a trap for slice not returning parameters in order to ensure that a result is returned to the callback function when leveraging the RegEx aspect.